### PR TITLE
Removed forced https from traefik

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "git.enableCommitSigning": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "git.enableCommitSigning": true
-}

--- a/apps/medusa.yml
+++ b/apps/medusa.yml
@@ -29,7 +29,6 @@
     - name: 'Adding Traefik'
       set_fact:
         pg_labels:
-          traefik.protocol: 'https'
           traefik.frontend.auth.forward.address: '{{gauth}}'
           traefik.enable: 'true'
           traefik.port: '{{intport}}'


### PR DESCRIPTION
Medusa had traefik.protocol set to 'https', but Medusa listens in http by default.