### PR TITLE
Removed OAUTH (breaks bitwarden-apps)

### DIFF
--- a/apps/bitwarden.yml
+++ b/apps/bitwarden.yml
@@ -28,7 +28,6 @@
           traefik.enable: 'true'
           traefik.backend: "{{pgrole}}"
           traefik.port: '80'
-          traefik.frontend.auth.forward.address: '{{gauth}}'
           traefik.frontend.rule: 'Host:bit.{{domain.stdout}},{{pgrole}}.{{domain.stdout}},{{tldset}}'
 
     - name: 'Setting PG Volumes'


### PR DESCRIPTION
Using oauth will cause Browser Extensions and Applications to be unable to load the server url properly. Removing this line fixes the problem. Login page is secured by accounts already.