### PR TITLE
Update to supported UniFi Controller image

### DIFF
--- a/apps/unifi.yml
+++ b/apps/unifi.yml
@@ -25,7 +25,7 @@
         extport5: '8443'
         intport6: '8880/tcp'
         extport6: '8880'
-        image: 'linuxserver/unifi:latest'
+        image: 'linuxserver/unifi-controller:latest'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'


### PR DESCRIPTION
LinuxServer.io has deprecated the container image that was being used in favor of a new build style.  Everything is compatible, but the new version has some better tagging to allow people to have the latest, specific versions, or LTS.  We SHOULD change this to allow asking for the 'LTS' or 'latest' tag for those that are using it.

More information here:
https://blog.linuxserver.io/2019/02/18/changes-to-our-unifi-image/