### PR TITLE
 Add www to TLD frontend rules

### DIFF
--- a/apps/_appsgen.sh
+++ b/apps/_appsgen.sh
@@ -8,7 +8,7 @@
 
 # Generates App List
 ls -la /opt/communityapps/apps/ | sed -e 's/.yml//g' \
-| awk '{print $9}' | tail -n +4 \
+| awk '{print $9}' | \
 sed -e "/traefik/d" | \
 sed -e "/image*/d" | \
 sed -e "/_appsgen.sh/d" | \
@@ -23,4 +23,5 @@ sed -e "/watchtower/d" | \
 sed "/^_templates.yml\b/Id" | \
 sed -e "/oauth/d" | \
 sed -e "/dockergc/d" | \
-sed -e "/pgui/d"
+sed -e "/pgui/d" | \
+tail -n +4 

--- a/apps/_appsgen.sh
+++ b/apps/_appsgen.sh
@@ -8,19 +8,19 @@
 
 # Generates App List
 ls -la /opt/communityapps/apps/ | sed -e 's/.yml//g' \
-| awk '{print $9}' \
-sed -i -e "/traefik/d" /var/plexguide/app.list \
-sed -i -e "/image*/d" /var/plexguide/app.list \
-sed -i -e "/_appsgen.sh/d" /var/plexguide/app.list \
-sed -i -e "/_c*/d" /var/plexguide/app.list \
-sed -i -e "/_a*/d" /var/plexguide/app.list \
-sed -i -e "/_t*/d" /var/plexguide/app.list \
-sed -i -e "/templates/d" /var/plexguide/app.list \
-sed -i -e "/retry/d" /var/plexguide/app.list \
-sed -i "/^test\b/Id" /var/plexguide/app.list \
-sed -i -e "/nzbthrottle/d" /var/plexguide/app.list \
-sed -i -e "/watchtower/d" /var/plexguide/app.list \
-sed -i "/^_templates.yml\b/Id" /var/plexguide/app.list \
-sed -i -e "/oauth/d" /var/plexguide/app.list \
-sed -i -e "/dockergc/d" /var/plexguide/app.list \
-sed -i -e "/pgui/d" /var/plexguide/app.list
+| awk '{print $9}' | \
+sed -i -e "/traefik/d" | \
+sed -i -e "/image*/d" | \
+sed -i -e "/_appsgen.sh/d" | \
+sed -i -e "/_c*/d" | \
+sed -i -e "/_a*/d" | \
+sed -i -e "/_t*/d" | \
+sed -i -e "/templates/d" | \
+sed -i -e "/retry/d" | \
+sed -i "/^test\b/Id" | \
+sed -i -e "/nzbthrottle/d" | \
+sed -i -e "/watchtower/d" | \
+sed -i "/^_templates.yml\b/Id" | \
+sed -i -e "/oauth/d" | \
+sed -i -e "/dockergc/d" | \
+sed -i -e "/pgui/d"

--- a/apps/_appsgen.sh
+++ b/apps/_appsgen.sh
@@ -8,23 +8,19 @@
 
 # Generates App List
 ls -la /opt/communityapps/apps/ | sed -e 's/.yml//g' \
-| awk '{print $9}' | tail -n +4  > /var/plexguide/app.list
-
-ls -la /opt/mycontainers/ | sed -e 's/.yml//g' \
-| awk '{print $9}' | tail -n +4  >> /var/plexguide/app.list
-# Enter Items Here to Prevent them From Showing Up on AppList
-sed -i -e "/traefik/d" /var/plexguide/app.list
-sed -i -e "/image*/d" /var/plexguide/app.list
-sed -i -e "/_appsgen.sh/d" /var/plexguide/app.list
-sed -i -e "/_c*/d" /var/plexguide/app.list
-sed -i -e "/_a*/d" /var/plexguide/app.list
-sed -i -e "/_t*/d" /var/plexguide/app.list
-sed -i -e "/templates/d" /var/plexguide/app.list
-sed -i -e "/retry/d" /var/plexguide/app.list
-sed -i "/^test\b/Id" /var/plexguide/app.list
-sed -i -e "/nzbthrottle/d" /var/plexguide/app.list
-sed -i -e "/watchtower/d" /var/plexguide/app.list
-sed -i "/^_templates.yml\b/Id" /var/plexguide/app.list
-sed -i -e "/oauth/d" /var/plexguide/app.list
-sed -i -e "/dockergc/d" /var/plexguide/app.list
+| awk '{print $9}' \
+sed -i -e "/traefik/d" /var/plexguide/app.list \
+sed -i -e "/image*/d" /var/plexguide/app.list \
+sed -i -e "/_appsgen.sh/d" /var/plexguide/app.list \
+sed -i -e "/_c*/d" /var/plexguide/app.list \
+sed -i -e "/_a*/d" /var/plexguide/app.list \
+sed -i -e "/_t*/d" /var/plexguide/app.list \
+sed -i -e "/templates/d" /var/plexguide/app.list \
+sed -i -e "/retry/d" /var/plexguide/app.list \
+sed -i "/^test\b/Id" /var/plexguide/app.list \
+sed -i -e "/nzbthrottle/d" /var/plexguide/app.list \
+sed -i -e "/watchtower/d" /var/plexguide/app.list \
+sed -i "/^_templates.yml\b/Id" /var/plexguide/app.list \
+sed -i -e "/oauth/d" /var/plexguide/app.list \
+sed -i -e "/dockergc/d" /var/plexguide/app.list \
 sed -i -e "/pgui/d" /var/plexguide/app.list

--- a/apps/_appsgen.sh
+++ b/apps/_appsgen.sh
@@ -9,18 +9,18 @@
 # Generates App List
 ls -la /opt/communityapps/apps/ | sed -e 's/.yml//g' \
 | awk '{print $9}' | \
-sed -i -e "/traefik/d" | \
-sed -i -e "/image*/d" | \
-sed -i -e "/_appsgen.sh/d" | \
-sed -i -e "/_c*/d" | \
-sed -i -e "/_a*/d" | \
-sed -i -e "/_t*/d" | \
-sed -i -e "/templates/d" | \
-sed -i -e "/retry/d" | \
-sed -i "/^test\b/Id" | \
-sed -i -e "/nzbthrottle/d" | \
-sed -i -e "/watchtower/d" | \
-sed -i "/^_templates.yml\b/Id" | \
-sed -i -e "/oauth/d" | \
-sed -i -e "/dockergc/d" | \
-sed -i -e "/pgui/d"
+sed -e "/traefik/d" | \
+sed -e "/image*/d" | \
+sed -e "/_appsgen.sh/d" | \
+sed -e "/_c*/d" | \
+sed -e "/_a*/d" | \
+sed -e "/_t*/d" | \
+sed -e "/templates/d" | \
+sed -e "/retry/d" | \
+sed "/^test\b/Id" | \
+sed -e "/nzbthrottle/d" | \
+sed -e "/watchtower/d" | \
+sed "/^_templates.yml\b/Id" | \
+sed -e "/oauth/d" | \
+sed -e "/dockergc/d" | \
+sed -e "/pgui/d"

--- a/apps/_appsgen.sh
+++ b/apps/_appsgen.sh
@@ -8,7 +8,7 @@
 
 # Generates App List
 ls -la /opt/communityapps/apps/ | sed -e 's/.yml//g' \
-| awk '{print $9}' | \
+| awk '{print $9}' | tail -n +4 \
 sed -e "/traefik/d" | \
 sed -e "/image*/d" | \
 sed -e "/_appsgen.sh/d" | \

--- a/apps/_core.yml
+++ b/apps/_core.yml
@@ -92,7 +92,7 @@
 
 - name: 'If Fact Matches - Enable TLD'
   set_fact:
-    tldset: '{{domain.stdout}}'
+    tldset: '{{domain.stdout}},www.{{domain.stdout}}'
   when: 'toplevel.stdout == pgrole'
 
 - debug: msg="TLDSET is now for {{toplevel.stdout}}"


### PR DESCRIPTION
Prevents a 404 error when trying to hit www.domain.com. I was unable to resolve this with either DNS wizardry nor modifying traefik.toml for redirects.