### PR TITLE
Don't let the community appsgen.sh clobber the core, just append

### DIFF
--- a/apps/_appsgen.sh
+++ b/apps/_appsgen.sh
@@ -8,7 +8,7 @@
 
 # Generates App List
 ls -la /opt/communityapps/apps/ | sed -e 's/.yml//g' \
-| awk '{print $9}' | tail -n +4  > /var/plexguide/app.list
+| awk '{print $9}' | tail -n +4  >> /var/plexguide/app.list
 
 ls -la /opt/mycontainers/ | sed -e 's/.yml//g' \
 | awk '{print $9}' | tail -n +4  >> /var/plexguide/app.list


### PR DESCRIPTION
Hey guys first PR for this project, not sure if you want this into `v8.6` or another spot?

This should fix the issue where generating the apps list, and the core apps get overwritten by the community apps list.  This is applicable for PG Shield when doing exceptions and also the watchtower app generation as well.

One of the threads about this is here: https://pgblitz.com/threads/exempt-ombi-from-pgshield.4904/