### PR TITLE
updating varken yml to use more up to date varken image

### DIFF
--- a/apps/varken.yml
+++ b/apps/varken.yml
@@ -16,7 +16,7 @@
         pgrole: 'varken'
         intport: '80'
         extport: '5985'
-        image: 'h1f0x/centos-varken'
+        image: 'vflagr/centos-varken'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'


### PR DESCRIPTION
This commit fixes the Varken image to update Varken to it's latest version.

This version requires an Access Key to be generated in order to use the map widget. Updated installs documentation can be found here: https://github.com/PGBlitz/PGBlitz.com/wiki/Varken